### PR TITLE
Adjusting formatting changes on documentation

### DIFF
--- a/documentation/latest/getting-started.html
+++ b/documentation/latest/getting-started.html
@@ -30,11 +30,15 @@
                     In case you want to depend on the latest SNAPSHOT versions of Jersey modules, the following repository
                     configuration needs to be added to your Maven project pom:
 
-                    </p><pre class="&#xA;    toolbar: false;&#xA;    brush: xml;&#xA;    gutter: false;">&lt;snapshotRepository&gt;
-                        &lt;id&gt;ossrh&lt;/id&gt;
-                    &lt;name&gt;Sonatype Nexus Snapshots&lt;/name&gt;
+            </p>
+            <pre class="&#xA;    toolbar: false;&#xA;    brush: xml;&#xA;    gutter: false;">
+            &lt;snapshotRepository&gt;
+                &lt;id&gt;ossrh&lt;/id&gt;
+                &lt;name&gt;Sonatype Nexus Snapshots&lt;/name&gt;
                 &lt;url&gt;https://jakarta.oss.sonatype.org/content/repositories/snapshots/&lt;/url&gt;
-            &lt;/snapshotRepository&gt;</pre><p>
+            &lt;/snapshotRepository&gt;
+            </pre>
+            <p>
                 </p></div><p>
         </p><p>
             Since starting from a Maven project is the most convenient way for working with Jersey, let's now have a look


### PR DESCRIPTION
I noticed the broken formatting for the snapshot repository. It fix it.